### PR TITLE
Move the Standards-Version line

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,8 @@ Build-Depends: cmake (>= 2.8),
                debhelper (>= 9),
                libgtk-3-dev,
                valac-0.26 | valac (>= 0.26)
-Standards-Version: 3.9.3
 
+Standards-Version: 3.9.3
 Package: com.github.dahenson.agenda
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}


### PR DESCRIPTION
Supposedly we need a newline before Standards-Version, not after.