### PR TITLE
Fixed GLib settings string

### DIFF
--- a/src/AgendaWindow.vala
+++ b/src/AgendaWindow.vala
@@ -25,7 +25,7 @@ namespace Agenda {
 
     public class AgendaWindow : Gtk.Window {
 
-        private GLib.Settings agenda_settings = new GLib.Settings ("net.launchpad.agenda-tasks");
+        private GLib.Settings agenda_settings = new GLib.Settings ("com.github.dahenson.agenda");
         private GLib.Settings privacy_setting = new GLib.Settings ("org.gnome.desktop.privacy");
 
         private enum Columns {


### PR DESCRIPTION
Fixes an issue where Agenda was segfaulting on missing settings schema. Should work fine on a fresh install now.

Fixes #30 