### PR TITLE
Prepare 1.0.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ set (DATADIR "${CMAKE_INSTALL_PREFIX}/share")
 set (PKGDATADIR "${DATADIR}/com.github.dahenson.agenda")
 set (GETTEXT_PACKAGE "com.github.dahenson.agenda")
 set (RELEASE_NAME "Piece of paper.")
-set (VERSION "1.0.7")
-set (VERSION_INFO "Development")
+set (VERSION "1.0.8")
+set (VERSION_INFO "Production")
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/data/com.github.dahenson.agenda.appdata.xml
+++ b/data/com.github.dahenson.agenda.appdata.xml
@@ -15,8 +15,16 @@
   </screenshots>
   <description>
     <p>
-      Agenda is a simple, slick, speedy and no-nonsense task manager.
-      Use it to keep track of the tasks that matter most.
+      Agenda is a simple, slick, speedy and no-nonsense task manager. Use it to keep track of the tasks that matter most.
+    </p>
+    <ul>
+      <li>Blazingly fast and light</li>
+      <li>Remembers your list until you clear completed tasks</li>
+      <li>Autocompletion for previously added tasks</li>
+      <li>Quit with the Esc key</li>
+    </ul>
+    <p>
+      I dare you to find an easier, faster, more beautiful task manager for elementary OS.
     </p>
   </description>
 </component>

--- a/data/com.github.dahenson.agenda.desktop
+++ b/data/com.github.dahenson.agenda.desktop
@@ -10,8 +10,3 @@ X-GNOME-Gettext-Domain=agenda
 X-GNOME-UsesNotifications=true
 Categories=Utility;Office;
 Keywords=Todo;Tasks;
-Actions=AboutDialog;
-
-[Desktop Action AboutDialog]
-Name=About Agenda
-Exec=com.github.dahenson.agenda -a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,6 @@
 com.github.dahenson.agenda (1.0) precise; urgency=low
 
-  * Initial Release.
-  * Fixed style issues
+  * Fixed style issues for dark and light variants
   * Looks good, and feels good!
 
- -- Dane Henson <thegreatdane@gmail.com>  Fri, 26 May 2017 10:02:26 -0500
+ -- Dane Henson <thegreatdane@gmail.com>  Thu, 8 June 2017 10:02:26 -0500

--- a/src/Agenda.vala
+++ b/src/Agenda.vala
@@ -21,44 +21,15 @@ using Granite;
 
 namespace Agenda {
 
-public class Agenda : Granite.Application {
+public class Agenda : Gtk.Application {
 
     private static Agenda app;
     private AgendaWindow window = null;
 
-    construct {
-
-        // App info
-        build_version = Build.VERSION;
-        build_data_dir = Build.DATADIR;
-        build_pkg_data_dir = Build.PKGDATADIR;
-        build_release_name = Build.RELEASE_NAME;
-        build_version_info = Build.VERSION_INFO;
-
-        program_name = "Agenda";
-        exec_name = "com.github.dahenson.agenda";
-
-        app_years = "2012-2017";
-        application_id = "com.github.dahenson.agenda";
-        app_icon = "com.github.dahenson.agenda";
-        app_launcher = "com.github.dahenson.agenda.desktop";
-
-        main_url = "https://github.com/dahenson/agenda";
-        bug_url = "https://github.com/dahenson/agenda/issues";
-        help_url = "https://answers.launchpad.net/agenda-tasks";
-        translate_url = "https://translations.launchpad.net/agenda-tasks";
-
-        about_authors = {"Tom Beckmann <tombeckmann@online.de>",
-                         "Dane Henson <thegreatdane@gmail.com>",
-                         "Cameron Norman <camerontnorman@gmail.com>",
-                         "Fabio Zaramella <ffabio.96.x@gmail.com>"};
-        about_documenters = {"Dane Henson <thegreatdane@gmail.com",
-                             "Tom Beckmann <tombeckmann@online.de>"};
-        about_artists = {"Harvey Cabaguio", "Sergey Davidoff"};
-        about_comments = _("A simple, slick, speedy, and no-nonsense task manager.");
-        about_translators = "";
-        about_license_type = Gtk.License.GPL_3_0;
-        }
+    public Agenda () {
+        Object (application_id: "com.github.dahenson.agenda",
+        flags: ApplicationFlags.FLAGS_NONE);
+    }
 
     protected override void activate () {
         // if app is already open


### PR DESCRIPTION
- Removed About dialog
- Added hype to the AppData file
- Bumped version