### PR TITLE
Remove box-shadow from titlebar

### DIFF
--- a/src/AgendaWindow.vala
+++ b/src/AgendaWindow.vala
@@ -58,6 +58,7 @@ namespace Agenda {
                 .titlebar {
                     background-color: @bg_color;
                     background-image: none;
+                    box-shadow: none;
                     border: none;
                 }
 


### PR DESCRIPTION
This remove a thin white border all around the titlebar.