### PR TITLE
Update the icon URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/dahenson/agenda.svg?branch=master)](https://travis-ci.org/dahenson/agenda)
 
 <p align="center">
-  <img src="https://cdn.rawgit.com/dahenson/agenda/readme-updates/data/icons/128/com.github.dahenson.agenda.svg" alt="Icon" />
+  <img src="https://cdn.rawgit.com/dahenson/agenda/master/data/icons/128/com.github.dahenson.agenda.svg" alt="Icon" />
 </p>
 <h1 align="center">Agenda</h1>
 <p align="center">


### PR DESCRIPTION
Fixes #75 

The URL seemed to be assigned the stale branch.

![screenshot from 2018-08-22 22-10-09](https://user-images.githubusercontent.com/26003928/44465324-31f0d600-a658-11e8-82ae-2af448998129.png)
