### PR TITLE
Minor Fixes to Pass vala-lint Check

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-09-08 13:29+0000\n"
 "Last-Translator: Tristan B. Kildaire <deavmi@gmail.com>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -18,85 +18,30 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-09-09 06:25+0000\n"
 "X-Generator: Launchpad (build 18184)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr ""
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Oor Agenda"
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr ""
+#~ msgid "Agenda"
+#~ msgstr "Oor Agenda"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2015-01-18 13:43+0000\n"
 "Last-Translator: Adolfo Jayme <fitoschido@gmail.com>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -18,88 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Afegeix una tasca nova…"
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "No hi ha cap tasca."
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(afegeu una a continuació)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(camí a seguir)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr ""
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Quant a l’Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Quant a l’Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Per fer;Tasques;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Per fer;Tasques;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Un gestor de tasques fàcil d’utilitzar."

--- a/po/com.github.dahenson.agenda.pot
+++ b/po/com.github.dahenson.agenda.pot
@@ -8,93 +8,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dahenson.agenda\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-06-07 23:35+0000\n"
 "Last-Translator: Casper Christiansen <casper.developer@gmail.com>\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Ingen Opgaver!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(godt klaret)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2015-09-03 22:02+0000\n"
 "Last-Translator: Daniel <launchlin@mailbox.org>\n"
 "Language-Team: German <de@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Neue Aufgabe hinzufügen..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Keine Aufgaben!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(unten hinzufügen)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(so soll's sein)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Zur Liste hinzufügen"
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Verlauf löschen"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Über Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Über Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Aufgabe erledigt"
+#~ msgid "Task List"
+#~ msgstr "Aufgabe erledigt"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Offenstehend;Aufgaben;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Offenstehend;Aufgaben;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2014-05-16 18:55+0000\n"
 "Last-Translator: Chris Triantafillis <Unknown>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Δεν υπάρχουν σημειώματα!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(σχεδόν τελειώσαμε)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-05-07 20:49+0000\n"
 "Last-Translator: Alfredo Hernández <Unknown>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "No Tasks!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(way to go)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-02-04 13:07+0000\n"
 "Last-Translator: Michael Moroni <michael.moroni@openmailbox.org>\n"
 "Language-Team: Esperanto <eo@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Neniu tasko!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-05-04 12:07+0000\n"
 "Last-Translator: Cameron Norman <camerontnorman@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-05-05 05:34+0000\n"
 "X-Generator: Launchpad (build 17995)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Añadir una nueva tarea…"
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "No hay tareas."
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(añada una más abajo)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(buen trabajo)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Añadir a la lista..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Borrar historial"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Acerca de Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Acerca de Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Tarea finalizada"
+#~ msgid "Task List"
+#~ msgstr "Tarea finalizada"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Por hacer;Tareas;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Por hacer;Tareas;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2014-01-11 18:04+0000\n"
 "Last-Translator: Cameron Norman <camerontnorman@gmail.com>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Tubli!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "Ülesandeid pole"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-08-13 19:22+0000\n"
 "Last-Translator: Jiri Grönroos <Unknown>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Ei tehtäviä!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-02-21 20:50+0000\n"
 "Last-Translator: Jean-Marc <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-02-22 05:52+0000\n"
 "X-Generator: Launchpad (build 17925)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Ajouter une nouvelle tâche…"
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Aucune tâche !"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(en ajouter une ci-dessous)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(bien joué)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Ajouter à la liste..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Effacer l'historique"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "À propos d'Agenda"
+#~ msgid "Agenda"
+#~ msgstr "À propos d'Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Tâche terminée"
+#~ msgid "Task List"
+#~ msgstr "Tâche terminée"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "À faire;Todo;Tâches"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "À faire;Todo;Tâches"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Un gestionnaire de tâches simple, rapide et élégant"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2014-01-11 15:43+0000\n"
 "Last-Translator: Brendan William <Unknown>\n"
 "Language-Team: French (Canada) <fr_CA@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Pas de tâches!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(voie à suivre)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2015-08-13 23:59+0000\n"
 "Last-Translator: Jon Amil <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -18,89 +18,41 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Engadir unha tarefa nova..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Non hai tarefas."
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(engadir unha debaixo)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(camiño a seguir)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr ""
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Acerca de Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Acerca de Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Tarefa concluída"
+#~ msgid "Task List"
+#~ msgstr "Tarefa concluída"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Facer;Tarefas;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Facer;Tarefas;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Un xestor de tarefas pulido, sinxelo, rápido e sen complicacións."

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-04-01 11:53+0000\n"
 "Last-Translator: Megolas <ofeklavie@gmail.com>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "אין משימות!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-07-28 08:06+0000\n"
 "Last-Translator: Viko Adi Rahmawan <Unknown>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Tak ada Tugas!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-01-23 16:41+0000\n"
 "Last-Translator: Fabio Zaramella <FFabio.96.X@Gmail.com>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Aggiungi una nuova attività..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Nessuna attività!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(aggiungi qui sotto)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(sei sulla strada giusta)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Aggiungi alla lista..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Cancella la cronologia"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Informazioni"
+#~ msgid "Agenda"
+#~ msgstr "Informazioni"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Compito terminato"
+#~ msgid "Task List"
+#~ msgstr "Compito terminato"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Da fare;compiti;attività;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Da fare;compiti;attività;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Un promemoria semplice, elegante, veloce e senza fronzoli."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dahenson.agenda\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-07 21:48+0900\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2020-02-08 07:57+0900\n"
 "Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: none\n"
@@ -18,7 +18,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: src/Window.vala:27
-msgid "Add a new task..."
+#, fuzzy
+msgid "Add a new task…"
 msgstr "新しいタスクを追加…"
 
 #: src/Window.vala:83
@@ -34,7 +35,8 @@ msgid "(way to go)"
 msgstr "(お疲れさまです)"
 
 #: src/Window.vala:168
-msgid "Add to list..."
+#, fuzzy
+msgid "Add to list…"
 msgstr "リストに追加…"
 
 #: src/Window.vala:194

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2015-11-17 19:46+0000\n"
 "Last-Translator: Beqa Arabuli <arabulibeqa@yahoo.com>\n"
 "Language-Team: Georgian <ka@li.org>\n"
@@ -18,89 +18,41 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "ახალი დავალების დამატება..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "დავალებები არაა!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(დაამატე ქვემოდან)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(ეგრე უნდა)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr ""
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Agenda-ს შესახებ"
+#~ msgid "Agenda"
+#~ msgstr "Agenda-ს შესახებ"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "დავალება დასრულებულია"
+#~ msgid "Task List"
+#~ msgstr "დავალება დასრულებულია"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "გასაკეთებელი;დავალებები;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "გასაკეთებელი;დავალებები;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr ""

--- a/po/km.po
+++ b/po/km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2014-04-13 08:42+0000\n"
 "Last-Translator: Sovichet <Unknown>\n"
 "Language-Team: Khmer <km@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "គ្មាន​កិច្ចការ!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(អបអរសាទរ)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2017-01-20 04:04+0000\n"
 "Last-Translator: MinSik CHO <Unknown>\n"
 "Language-Team: Korean <ko@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2017-01-21 06:43+0000\n"
 "X-Generator: Launchpad (build 18302)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "새 할 일 추가하기..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "할 일이 없습니다!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(아래에 추가)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(추후 추가 예정)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "리스트에 추가..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "기록 삭제"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "어젠다에 대해서"
+#~ msgid "Agenda"
+#~ msgstr "어젠다에 대해서"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "작업 완료"
+#~ msgid "Task List"
+#~ msgstr "작업 완료"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "할 일;일정;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "할 일;일정;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "간단하고 미려한 일정 관리자"

--- a/po/la.po
+++ b/po/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-02-21 16:41+0000\n"
 "Last-Translator: Mikael Hiort af Ornäs <lakritslemmel@hotmail.com>\n"
 "Language-Team: Latin <la@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Nullae res propositae!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(bene factum)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-08-04 12:42+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-08-05 05:38+0000\n"
 "X-Generator: Launchpad (build 18169)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Pridėti naują užduotį..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Nėra užduočių!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(pridėkite jas žemiau)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(taip ir toliau)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Pridėti į sąrašą..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Išvalyti istoriją"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Apie Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Apie Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Užduotis baigta"
+#~ msgid "Task List"
+#~ msgstr "Užduotis baigta"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Atlikti;Užduotys;Užduotis;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Atlikti;Užduotys;Užduotis;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Paprasta, vikri, greita, dalykiška užduočių tvarkytuvė."

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2015-09-22 07:21+0000\n"
 "Last-Translator: abuyop <Unknown>\n"
 "Language-Team: Malay <ms@li.org>\n"
@@ -18,89 +18,41 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Tambah tugas baharu..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Tiada Tugas!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(satu satu di bawah)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(lagi)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr ""
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Perihal Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Perihal Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Tugas selesai"
+#~ msgid "Task List"
+#~ msgstr "Tugas selesai"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Todo;Tugas;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Todo;Tugas;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Pengurus tugas yang ringkas dan pantas."

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2014-03-31 13:08+0000\n"
 "Last-Translator: Magnus Meyer Hustveit <Unknown>\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Ingen oppgaver!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(bra jobba)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-05-17 19:26+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-05-18 05:40+0000\n"
 "X-Generator: Launchpad (build 18025)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2014-10-20 20:39+0000\n"
 "Last-Translator: Martin Myrvold <Unknown>\n"
 "Language-Team: Norwegian Nynorsk <nn@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Ingen oppgåver!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(legg til ei nedanfor)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(bra jobba)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-02-01 09:45+0000\n"
 "Last-Translator: Piotr Strębski <strebski@o2.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-02-02 05:39+0000\n"
 "X-Generator: Launchpad (build 17908)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Dodaj nowe zadanie..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Brak zadań!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(dodaj jedno poniżej)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(do końca)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Dodaj do listy..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Wyczyść historię"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "O programie Agenda"
+#~ msgid "Agenda"
+#~ msgstr "O programie Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Zadanie zakończone"
+#~ msgid "Task List"
+#~ msgstr "Zadanie zakończone"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Todo;Zadania;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Todo;Zadania;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Prosty, gładki, szybki i niebezsensowny menedżer zadań."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-09-14 00:25+0000\n"
 "Last-Translator: Sérgio Marques <Unknown>\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Nenhuma tarefa!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(assim mesmo)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2017-02-23 20:16+0000\n"
 "Last-Translator: Vaguiner Gonzalez <vaguiners@live.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -18,89 +18,38 @@ msgstr ""
 "X-Launchpad-Export-Date: 2017-02-25 05:56+0000\n"
 "X-Generator: Launchpad (build 18328)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Adicione nova tarefa..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Sem tarefas!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(e uma abaixo)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(modo de ir)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Limpar histórico"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Sobre Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Sobre Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Tarefa concluída"
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr ""
+#~ msgid "Task List"
+#~ msgstr "Tarefa concluída"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Um gestor de tarefas simples, liso, rápido e sem falhas."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-03-29 14:38+0000\n"
 "Last-Translator: Eugene Marshal <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-03-30 06:13+0000\n"
 "X-Generator: Launchpad (build 17967)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Создать новую задачу..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Задачи отсутствуют!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(добавить один ниже)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(хорошая работа)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Добавить в список..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Очистить журнал"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Сведения о Agenda"
+#~ msgid "Agenda"
+#~ msgstr "Сведения о Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Задание завершено"
+#~ msgid "Task List"
+#~ msgstr "Задание завершено"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Задачи;Планы"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Задачи;Планы"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Простой и быстрый менеджер задач"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-12-18 09:05+0000\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <sr@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-12-19 05:27+0000\n"
 "X-Generator: Launchpad (build 18298)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Додај нови задатак..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Нема задатака!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(додајте један испод)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(куда да се иде)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Додај на списак..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Очисти историјат"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "О Агенди"
+#~ msgid "Agenda"
+#~ msgstr "О Агенди"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Задатак је обављен"
+#~ msgid "Task List"
+#~ msgstr "Задатак је обављен"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Урадити;Задаци;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Урадити;Задаци;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Једноставан, гладак, брз и без којештарија управник задатака."

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-07-03 21:59+0000\n"
 "Last-Translator: Иван Благојевић <ivan_blagojevic@mail.com>\n"
 "Language-Team: Serbian Latin <sr@latin@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Nema zadataka!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(way to go)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2013-02-21 16:16+0000\n"
 "Last-Translator: Mikael Hiort af Ornäs <lakritslemmel@hotmail.com>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -18,84 +18,26 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Inga uppgifter!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(bra gjort)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
-msgid "Task List"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-04-15 15:52+0000\n"
 "Last-Translator: Melih Güçlü <melihguclu@hotmail.com>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-04-16 05:41+0000\n"
 "X-Generator: Launchpad (build 17995)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "Yeni bir görev ekle..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "Görev yok!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(aşagıdan bir tane ekleyin)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "helal olsun"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "Listeye ekle..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "Geçmişi temizle"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "Ajanda Hakkında"
+#~ msgid "Agenda"
+#~ msgstr "Ajanda Hakkında"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "Görev tamamlandı"
+#~ msgid "Task List"
+#~ msgstr "Görev tamamlandı"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Yapılacaklar;Görevler;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Yapılacaklar;Görevler;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "Basit, şık, hızlı ve zırvalıksız görev yöneticisi"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2015-10-24 12:36+0000\n"
 "Last-Translator: Eltikin <eltikinuyghur@hotmail.com>\n"
 "Language-Team: Uyghur <ug@li.org>\n"
@@ -18,85 +18,30 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-01-26 05:28+0000\n"
 "X-Generator: Launchpad (build 17902)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+msgid "Add a new task…"
 msgstr ""
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "ۋەزىپە يوق!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr ""
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(غەيرەت قىلىڭ)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+msgid "Add to list…"
 msgstr ""
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr ""
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
-msgid "Agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "ۋەزىپە ئۇرۇنلىنىپ بولدى"
-
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr ""
+#~ msgid "Task List"
+#~ msgstr "ۋەزىپە ئۇرۇنلىنىپ بولدى"

--- a/po/ur.po
+++ b/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-10-16 11:24+0000\n"
 "Last-Translator: Waqar Ahmed <waqar.17a@gmail.com>\n"
 "Language-Team: Urdu <ur@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-10-17 06:47+0000\n"
 "X-Generator: Launchpad (build 18232)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "ایک نیا کام شامل کریں ..."
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "کوئی کام نہیں!"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(نیچے ایک کو شامل کریں)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr ""
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "فہرست میں شامل کریں..."
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "ہسٹری صاف کریں"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "ایجچڈا کے بارے میں"
+#~ msgid "Agenda"
+#~ msgstr "ایجچڈا کے بارے میں"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "کام مکمل ہو گیا"
+#~ msgid "Task List"
+#~ msgstr "کام مکمل ہو گیا"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "ہونے والے کام؛ ٹاسک؛ کام"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "ہونے والے کام؛ ٹاسک؛ کام"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "ایک سادہ، ہوشیار، فوری اور سیداہ سادہ ٹاسک مینیجر."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: agenda-tasks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-22 00:03-0600\n"
+"POT-Creation-Date: 2020-02-15 18:09-0600\n"
 "PO-Revision-Date: 2016-02-24 22:54+0000\n"
 "Last-Translator: Mingye Wang <arthur2e5@aosc.xyz>\n"
 "Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
@@ -18,89 +18,42 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-02-25 05:17+0000\n"
 "X-Generator: Launchpad (build 17925)\n"
 
-#: src/AgendaWindow.vala:27
-msgid "Add a new task..."
+#: src/Window.vala:27
+#, fuzzy
+msgid "Add a new task…"
 msgstr "新增任务…"
 
-#: src/AgendaWindow.vala:69
+#: src/Window.vala:83
 msgid "No Tasks!"
 msgstr "无任务！"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(add one below)"
 msgstr "(在下面加入一个)"
 
-#: src/AgendaWindow.vala:70
+#: src/Window.vala:84
 msgid "(way to go)"
 msgstr "(加油)"
 
-#: src/AgendaWindow.vala:150
-msgid "Add to list..."
+#: src/Window.vala:168
+#, fuzzy
+msgid "Add to list…"
 msgstr "加入列表…"
 
-#: src/AgendaWindow.vala:179
+#: src/Window.vala:194
 msgid "Clear history"
 msgstr "清除历史"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:7
-#: data/com.github.dahenson.agenda.desktop.in:4
 #, fuzzy
-msgid "Agenda"
-msgstr "关于 Agenda"
+#~ msgid "Agenda"
+#~ msgstr "关于 Agenda"
 
-#: data/com.github.dahenson.agenda.appdata.xml.in:8
-#: data/com.github.dahenson.agenda.desktop.in:5
-msgid "Get things done"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:9
-msgid "Dane Henson"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:24
-msgid "A task manager to help you keep track of the tasks that matter most."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:27
-msgid ""
-"Sometimes, you just need a task list to keep you motivated. Agenda provides "
-"a way to write down your tasks and tick them off as you complete them. The "
-"list is saved automatically, so you can close the list to get it out of the "
-"way without losing your place."
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:30
-msgid "Key Features:"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:32
-msgid "Saves your task list automatically"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:33
-msgid "See your completed tasks until you choose to delete them"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:34
-msgid "Autocompletion for previously added tasks"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.appdata.xml.in:35
-msgid "Quit with the Esc key"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:6
 #, fuzzy
-msgid "Task List"
-msgstr "任务已完成"
+#~ msgid "Task List"
+#~ msgstr "任务已完成"
 
-#: data/com.github.dahenson.agenda.desktop.in:8
-msgid "com.github.dahenson.agenda"
-msgstr ""
-
-#: data/com.github.dahenson.agenda.desktop.in:13
-msgid "Todo;Tasks;"
-msgstr "Todo;Tasks;待办;事项;"
+#~ msgid "Todo;Tasks;"
+#~ msgstr "Todo;Tasks;待办;事项;"
 
 #~ msgid "A simple, slick, speedy and no-nonsense task manager."
 #~ msgstr "简单流畅、快速不脑残的任务规划管理器。"

--- a/src/Agenda.vala
+++ b/src/Agenda.vala
@@ -40,7 +40,7 @@ namespace Agenda {
             }
 
             window = new AgendaWindow (this);
-            window.delete_event.connect(window.main_quit);
+            window.delete_event.connect (window.main_quit);
             window.show_all ();
             window.update ();
 

--- a/src/Models/HistoryList.vala
+++ b/src/Models/HistoryList.vala
@@ -24,7 +24,7 @@ namespace Agenda {
     public class HistoryList : Gtk.ListStore {
 
         construct {
-            Type[] types = { typeof(string) };
+            Type[] types = { typeof (string) };
             set_column_types (types);
         }
 

--- a/src/Models/TaskList.vala
+++ b/src/Models/TaskList.vala
@@ -49,12 +49,12 @@ namespace Agenda {
             undo_list = new TaskListHistory ();
 
             Type[] types = {
-                typeof(bool),
-                typeof(string),
-                typeof(bool),
-                typeof(string),
-                typeof(string),
-                typeof(string)
+                typeof (bool),
+                typeof (string),
+                typeof (bool),
+                typeof (string),
+                typeof (string),
+                typeof (string)
             };
 
             set_column_types (types);
@@ -123,7 +123,7 @@ namespace Agenda {
 
                 if (list_id == id)
                     count++;
-                valid = iter_next(ref iter);
+                valid = iter_next (ref iter);
             }
 
             if (count > 1)
@@ -262,7 +262,7 @@ namespace Agenda {
 
         public void remove_completed_tasks () {
             Gtk.TreeIter iter;
-            bool valid  = get_iter_first (out iter);
+            bool valid = get_iter_first (out iter);
             bool active;
             int counter = 0;
 

--- a/src/Models/TaskListHistory.vala
+++ b/src/Models/TaskListHistory.vala
@@ -41,7 +41,7 @@ namespace Agenda {
 
         public void add (TaskList state) {
             if (iter.has_next ()) {
-                var temp_list = list.slice(0, iter.index () + 1);
+                var temp_list = list.slice (0, iter.index () + 1);
                 list.retain_all (temp_list);
             }
 
@@ -70,4 +70,3 @@ namespace Agenda {
         }
     }
 }
-

--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -51,11 +51,11 @@ namespace Agenda {
             valign = Gtk.Align.FILL;
             reorderable = true;
 
-            var column        = new Gtk.TreeViewColumn ();
-            var text          = new Gtk.CellRendererText ();
-            var toggle        = new Gtk.CellRendererToggle ();
+            var column = new Gtk.TreeViewColumn ();
+            var text = new Gtk.CellRendererText ();
+            var toggle = new Gtk.CellRendererToggle ();
             var delete_button = new Gtk.CellRendererPixbuf ();
-            var draghandle    = new Gtk.CellRendererPixbuf ();
+            var draghandle = new Gtk.CellRendererPixbuf ();
 
             // Setup the TOGGLE column
             toggle.xpad = 6;
@@ -82,7 +82,7 @@ namespace Agenda {
             delete_button.xpad = 6;
             column = new Gtk.TreeViewColumn.with_attributes (
                 "Delete", delete_button, "icon_name", TaskList.Columns.DELETE);
-            append_column(column);
+            append_column (column);
 
             // Setup the DRAGHANDLE column
             draghandle.xpad = 6;
@@ -160,4 +160,3 @@ namespace Agenda {
         }
     }
 }
-

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -24,7 +24,7 @@ namespace Agenda {
     const int MIN_WIDTH = 500;
     const int MIN_HEIGHT = 600;
 
-    const string HINT_STRING = _("Add a new task...");
+    const string HINT_STRING = _("Add a new task…");
 
     public class AgendaWindow : Gtk.ApplicationWindow {
 
@@ -37,15 +37,15 @@ namespace Agenda {
         File history_file;
 
         private Granite.Widgets.Welcome agenda_welcome;
-        private TaskView                task_view;
-        private TaskList                task_list;
-        private Gtk.ScrolledWindow      scrolled_window;
-        private Gtk.Entry               task_entry;
-        private Gtk.Grid                grid;
-        private HistoryList             history_list;
-        private Gtk.SeparatorMenuItem   separator;
-        private Gtk.MenuItem            item_clear_history;
-        private bool                    is_editing;
+        private TaskView task_view;
+        private TaskList task_list;
+        private Gtk.ScrolledWindow scrolled_window;
+        private Gtk.Entry task_entry;
+        private Gtk.Grid grid;
+        private HistoryList history_list;
+        private Gtk.SeparatorMenuItem separator;
+        private Gtk.MenuItem item_clear_history;
+        private bool is_editing;
 
         public AgendaWindow (Agenda app) {
             Object (application: app);
@@ -62,16 +62,16 @@ namespace Agenda {
                                        {"<Ctrl>Y"});
 
             this.get_style_context ().add_class ("rounded");
-            this.set_size_request(MIN_WIDTH, MIN_HEIGHT);
+            this.set_size_request (MIN_WIDTH, MIN_HEIGHT);
 
             // Set up geometry
-            Gdk.Geometry geo = Gdk.Geometry();
+            Gdk.Geometry geo = Gdk.Geometry ();
             geo.min_width = MIN_WIDTH;
             geo.min_height = MIN_HEIGHT;
             geo.max_width = 1024;
             geo.max_height = 2048;
 
-            this.set_geometry_hints(
+            this.set_geometry_hints (
                 null,
                 geo,
                 Gdk.WindowHints.MIN_SIZE | Gdk.WindowHints.MAX_SIZE);
@@ -159,13 +159,13 @@ namespace Agenda {
             this.set_title ("Agenda");
 
             task_entry.name = "TaskEntry";
-            task_entry.get_style_context().add_class("task-entry");
+            task_entry.get_style_context ().add_class ("task-entry");
             task_entry.placeholder_text = HINT_STRING;
             task_entry.max_length = 64;
             task_entry.hexpand = true;
             task_entry.valign = Gtk.Align.START;
             task_entry.set_icon_tooltip_text (
-                Gtk.EntryIconPosition.SECONDARY, _("Add to list..."));
+                Gtk.EntryIconPosition.SECONDARY, _("Add to list…"));
 
             Gtk.EntryCompletion completion = new Gtk.EntryCompletion ();
             completion.set_model (history_list);
@@ -176,7 +176,7 @@ namespace Agenda {
             task_entry.activate.connect (append_task);
             task_entry.icon_press.connect (append_task);
 
-            task_entry.changed.connect(() => {
+            task_entry.changed.connect (() => {
                 var str = task_entry.get_text ();
                 if ( str == "" ) {
                     task_entry.set_icon_from_icon_name (
@@ -224,7 +224,7 @@ namespace Agenda {
                  *  through DND.  This also takes care of the toggled row, since
                  *  it is removed and the row_deleted signal is emitted.
                  */
-                save_list (task_list.get_all_tasks(), list_file);
+                save_list (task_list.get_all_tasks (), list_file);
                 update ();
             });
 
@@ -266,7 +266,12 @@ namespace Agenda {
         }
 
         public bool privacy_mode_off () {
-            return privacy_setting.get_boolean ("remember-app-usage") || privacy_setting.get_boolean ("remember-recent-files");
+            bool remember_app_usage = privacy_setting.get_boolean
+                ("remember-app-usage");
+            bool remember_recent_files = privacy_setting.get_boolean
+                ("remember-recent-files");
+
+            return remember_app_usage || remember_recent_files;
         }
 
         public void restore_window_position () {
@@ -285,7 +290,7 @@ namespace Agenda {
             }
 
             if (win_size.n_children () == 2) {
-                var width =  (int32) win_size.get_child_value (0);
+                var width = (int32) win_size.get_child_value (0);
                 var height = (int32) win_size.get_child_value (1);
                 debug ("Resizing to width and height: %d, %d", width, height);
                 this.resize (width, height);
@@ -305,7 +310,7 @@ namespace Agenda {
         }
 
         public bool main_quit () {
-            save_list (task_list.get_all_tasks(), list_file);
+            save_list (task_list.get_all_tasks (), list_file);
             history_to_file ();
             save_window_position ();
             this.destroy ();

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -266,10 +266,8 @@ namespace Agenda {
         }
 
         public bool privacy_mode_off () {
-            bool remember_app_usage = privacy_setting.get_boolean
-                ("remember-app-usage");
-            bool remember_recent_files = privacy_setting.get_boolean
-                ("remember-recent-files");
+            bool remember_app_usage = privacy_setting.get_boolean ("remember-app-usage");
+            bool remember_recent_files = privacy_setting.get_boolean ("remember-recent-files");
 
             return remember_app_usage || remember_recent_files;
         }

--- a/test/TestTaskList.vala
+++ b/test/TestTaskList.vala
@@ -134,12 +134,12 @@ public class TaskListTests : Gee.TestCase {
         test_list.append_task ("third task");
 
         // Simulate drag and drop reorder
-        test_list.insert_task(task1, "first task", false);
-        test_list.remove_task(new Gtk.TreePath.from_string("0"));
-        assert(test_list.size == 3);
+        test_list.insert_task (task1, "first task", false);
+        test_list.remove_task (new Gtk.TreePath.from_string ("0"));
+        assert (test_list.size == 3);
 
         test_list.undo ();
-        assert(test_list.size == 3);
+        assert (test_list.size == 3);
     }
 
     public void test_copy () {
@@ -160,4 +160,3 @@ public class TaskListTests : Gee.TestCase {
         assert (!test_list.contains (task3));
     }
 }
-

--- a/test/TestTaskListHistory.vala
+++ b/test/TestTaskListHistory.vala
@@ -94,4 +94,3 @@ public class TaskListHistoryTests : Gee.TestCase {
         assert (test_list.size == 2);
     }
 }
-

--- a/test/TestTaskListHistoryMain.vala
+++ b/test/TestTaskListHistoryMain.vala
@@ -26,4 +26,3 @@ void main (string[] args) {
 
     Test.run ();
 }
-

--- a/test/TestTaskListMain.vala
+++ b/test/TestTaskListMain.vala
@@ -26,4 +26,3 @@ void main (string[] args) {
 
     Test.run ();
 }
-


### PR DESCRIPTION
I ran `vala-lint` on the source code and fixed all of the warnings.

This also includes a slight change to the translation files that changes two strings to use ellipses instead of three dots (`...`).