### PR TITLE
Add vala-lint Continuous Integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: valalang/lint
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Lint
+      run: io.elementary.vala-lint -d ./src/

--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -107,7 +107,7 @@ namespace Agenda {
                 Gtk.TreePath p = new Gtk.TreePath ();
                 get_path_at_pos ((int) event.x, (int) event.y, out p, null, null, null);
                 if (p == null) {
-                    get_selection().unselect_all ();
+                    get_selection ().unselect_all ();
                     p.free ();
                     return true;
                 }


### PR DESCRIPTION
This just adds a github workflow to run `vala-lint` as a CI job on any push or pull request.