### PR TITLE
Fix race conditions with file reading and writing

### DIFF
--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -107,7 +107,7 @@ namespace Agenda {
                 Gtk.TreePath p = new Gtk.TreePath ();
                 get_path_at_pos ((int) event.x, (int) event.y, out p, null, null, null);
                 if (p == null) {
-                    get_selection().unselect_all ();
+                    get_selection ().unselect_all ();
                     p.free ();
                     return true;
                 }


### PR DESCRIPTION
We need better handling of opening/writing/closing files. This uses better error handling to deal with file creation and opening. Instead of relying on trying to see if a file exists, or is persisted, just do the thing and handle any errors that arise.