### PR TITLE
Persist tasks on change

### DIFF
--- a/src/Models/TaskList.vala
+++ b/src/Models/TaskList.vala
@@ -302,6 +302,14 @@ namespace Agenda {
             list_changed ();
         }
 
+        public void set_task_text (string path, string text) {
+            Gtk.TreeIter iter;
+            var tree_path = new Gtk.TreePath.from_string (path);
+
+            get_iter (out iter, tree_path);
+            set (iter, TaskList.Columns.TEXT, text);
+        }
+
         public void toggle_task (Gtk.TreePath path) {
             bool toggle;
             Gtk.TreeIter iter;

--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -23,23 +23,12 @@ namespace Agenda {
 
     public class TaskView : Gtk.TreeView {
 
-        public signal void task_deleted ();
-        public signal void task_added ();
-
         private TaskList task_list;
         public bool is_editing;
 
         public TaskView.with_list (TaskList list) {
             task_list = list;
             model = task_list;
-
-            task_list.row_deleted.connect ((path) => {
-                task_deleted ();
-            });
-
-            task_list.row_inserted.connect ((path) => {
-                task_added ();
-            });
         }
 
         construct {
@@ -118,16 +107,15 @@ namespace Agenda {
 
         public void toggle_selected_task () {
             Gtk.TreeIter iter;
-            Gtk.TreeSelection tree_selection;
-            bool current_state;
 
-            tree_selection = get_selection ();
+            var tree_selection = get_selection ();
             tree_selection.get_selected (null, out iter);
-            task_list.get (iter, 0, out current_state);
+            Gtk.TreePath path = task_list.get_path (iter);
+            if (path != null) {
+                task_list.toggle_task (path);
+            }
 
-            task_list.set (iter,
-                           TaskList.Columns.TOGGLE, !current_state,
-                           TaskList.Columns.STRIKETHROUGH, !current_state);
+            path.free ();
         }
 
         private void list_row_activated (Gtk.TreePath path, Gtk.TreeViewColumn column) {

--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -147,10 +147,7 @@ namespace Agenda {
             if (task_is_empty (edited_text)) {
                 return;
             }
-
-            Gtk.TreeIter iter;
-            task_list.get_iter (out iter, new Gtk.TreePath.from_string (path));
-            task_list.set (iter, TaskList.Columns.TEXT, edited_text);
+            task_list.set_task_text (path, edited_text);
             is_editing = false;
         }
     }

--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -101,7 +101,7 @@ namespace Agenda {
             });
 
             text.edited.connect (text_edited);
-            toggle.toggled.connect (task_toggled);
+            toggle.toggled.connect (toggle_clicked);
             row_activated.connect (list_row_activated);
             button_press_event.connect ((event) => {
                 Gtk.TreePath p = new Gtk.TreePath ();
@@ -149,13 +149,9 @@ namespace Agenda {
             }
         }
 
-        private void task_toggled (Gtk.CellRendererToggle toggle, string path) {
+        private void toggle_clicked (Gtk.CellRendererToggle toggle, string path) {
             var tree_path = new Gtk.TreePath.from_string (path);
-            Gtk.TreeIter iter;
-            task_list.get_iter (out iter, tree_path);
-            task_list.set (iter,
-                TaskList.Columns.TOGGLE, !toggle.active,
-                TaskList.Columns.STRIKETHROUGH, !toggle.active);
+            task_list.toggle_task (tree_path);
         }
 
         private void text_edited (string path, string edited_text) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -35,16 +35,12 @@ namespace Agenda {
 
         private FileBackend backend;
 
-        private Gtk.HeaderBar header;
         private Granite.Widgets.Welcome agenda_welcome;
         private TaskView task_view;
         private TaskList task_list;
         private Gtk.ScrolledWindow scrolled_window;
         private Gtk.Entry task_entry;
-        private Gtk.Grid grid;
         private HistoryList history_list;
-        private Gtk.SeparatorMenuItem separator;
-        private Gtk.MenuItem item_clear_history;
 
         public AgendaWindow (Agenda app) {
             Object (application: app);
@@ -63,7 +59,7 @@ namespace Agenda {
             this.get_style_context ().add_class ("rounded");
             this.set_size_request (MIN_WIDTH, MIN_HEIGHT);
 
-            header = new Gtk.HeaderBar ();
+            var header = new Gtk.HeaderBar ();
             header.show_close_button = true;
             header.get_style_context ().add_class ("titlebar");
             header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
@@ -91,7 +87,6 @@ namespace Agenda {
             task_view = new TaskView.with_list (task_list);
             scrolled_window = new Gtk.ScrolledWindow (null, null);
             task_entry = new Gtk.Entry ();
-            grid = new Gtk.Grid ();
 
             history_list = new HistoryList ();
 
@@ -162,8 +157,8 @@ namespace Agenda {
             task_entry.populate_popup.connect ((menu) => {
                 Gtk.TreeIter iter;
                 bool valid = history_list.get_iter_first (out iter);
-                separator = new Gtk.SeparatorMenuItem ();
-                item_clear_history = new Gtk.MenuItem.with_label (_("Clear history"));
+                var separator = new Gtk.SeparatorMenuItem ();
+                var item_clear_history = new Gtk.MenuItem.with_label (_("Clear history"));
 
                 menu.insert (separator, 6);
                 menu.insert (item_clear_history, 7);
@@ -188,19 +183,8 @@ namespace Agenda {
                 return false;
             });
 
-            task_view.task_deleted.connect (() => {
-                /**
-                 *  When a row is dragged and dropped, a new row is inserted,
-                 *  then populated, then the old row is deleted.  This way, we
-                 *  write the new order to the file every time it gets reordered
-                 *  through DND.  This also takes care of the toggled row, since
-                 *  it is removed and the row_deleted signal is emitted.
-                 */
+            task_list.list_changed.connect (() => {
                 backend.save_tasks (task_list.get_all_tasks ());
-                update ();
-            });
-
-            task_view.task_added.connect (() => {
                 update ();
             });
 
@@ -214,6 +198,7 @@ namespace Agenda {
 
             agenda_welcome.expand = true;
 
+            var grid = new Gtk.Grid ();
             grid.expand = true;
             grid.row_homogeneous = false;
             grid.attach (agenda_welcome, 0, 0, 1, 1);

--- a/test/TestTaskList.vala
+++ b/test/TestTaskList.vala
@@ -36,6 +36,7 @@ public class TaskListTests : Gee.TestCase {
         add_test ("[TaskList] test get_all_tasks", test_get_all_tasks);
         add_test ("[TaskList] test get_task", test_get_task);
         add_test ("[TaskList] test remove_task", test_remove_task);
+        add_test ("[TaskList] test toggle_task", test_toggle_task);
         add_test ("[TaskList] test undo append", test_undo_append);
         add_test ("[TaskList] test undo remove", test_undo_remove);
         add_test ("[TaskList] test redo append", test_redo_append);
@@ -111,6 +112,19 @@ public class TaskListTests : Gee.TestCase {
         assert (test_list.size == 1);
         assert (!test_list.contains (test_task_1.id));
         assert (test_list.contains (test_task_2.id));
+    }
+
+    public void test_toggle_task () {
+        test_list.append_task (test_task_1);
+
+        var tree_path = new Gtk.TreePath.from_string ("0");
+        test_list.toggle_task (tree_path);
+
+        Gtk.TreeIter iter;
+        test_list.get_iter (out iter, tree_path);
+
+        var t = test_list.get_task (iter);
+        assert (t.complete == !test_task_1.complete);
     }
 
     public void test_undo_append () {

--- a/test/TestTaskList.vala
+++ b/test/TestTaskList.vala
@@ -37,6 +37,7 @@ public class TaskListTests : Gee.TestCase {
         add_test ("[TaskList] test get_task", test_get_task);
         add_test ("[TaskList] test remove_task", test_remove_task);
         add_test ("[TaskList] test toggle_task", test_toggle_task);
+        add_test ("[TaskList] test set_task_text", test_set_task_text);
         add_test ("[TaskList] test undo append", test_undo_append);
         add_test ("[TaskList] test undo remove", test_undo_remove);
         add_test ("[TaskList] test redo append", test_redo_append);
@@ -125,6 +126,18 @@ public class TaskListTests : Gee.TestCase {
 
         var t = test_list.get_task (iter);
         assert (t.complete == !test_task_1.complete);
+    }
+
+    public void test_set_task_text () {
+        test_list.append_task (test_task_1);
+        test_list.set_task_text ("0", "New Text");
+
+        Gtk.TreeIter iter;
+        var tree_path = new Gtk.TreePath.from_string ("0");
+        test_list.get_iter (out iter, tree_path);
+
+        var t = test_list.get_task (iter);
+        assert (t.text == "New Text");
     }
 
     public void test_undo_append () {


### PR DESCRIPTION
This should fix #100 by persisting every change to disk instead of persisting when closed. This also helps clean up some of the classes and some unused code.