### PR TITLE
Added limit to editable characters in all text entries

### DIFF
--- a/src/Widgets/TaskView.vala
+++ b/src/Widgets/TaskView.vala
@@ -21,6 +21,7 @@
 
 namespace Agenda {
 
+
     public class TaskView : Gtk.TreeView {
 
         private TaskList task_list;
@@ -58,6 +59,8 @@ namespace Agenda {
             text.ypad = 6;
             text.editable = true;
             text.max_width_chars = 10;
+            text.wrap_width = 50;
+            text.wrap_mode = Pango.WrapMode.WORD_CHAR;
             text.ellipsize_set = true;
             text.ellipsize = Pango.EllipsizeMode.END;
 
@@ -82,6 +85,7 @@ namespace Agenda {
             set_tooltip_column (TaskList.Columns.TEXT);
 
             text.editing_started.connect ( (editable, path) => {
+                debug ("Editing started");
                 is_editing = true;
             });
 
@@ -144,10 +148,17 @@ namespace Agenda {
 
         private void text_edited (string path, string edited_text) {
             /* If the user accidentally blanks a task, abort the edit */
+
+            debug ("String: %s length: %d", edited_text, edited_text.length);
             if (task_is_empty (edited_text)) {
                 return;
             }
-            task_list.set_task_text (path, edited_text);
+            if (edited_text.length > EDITED_TEXT_MAX_LEN) {
+                string new_cut_text = edited_text.slice(0, EDITED_TEXT_MAX_LEN);
+                task_list.set_task_text (path, new_cut_text);
+            } else {
+                task_list.set_task_text (path, edited_text);
+            }
             is_editing = false;
         }
     }

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -23,6 +23,8 @@ namespace Agenda {
 
     const int MIN_WIDTH = 500;
     const int MIN_HEIGHT = 600;
+    // Limit for any edited text
+    const int EDITED_TEXT_MAX_LEN = 10;
 
     const string HINT_STRING = _("Add a new task…");
 
@@ -134,7 +136,7 @@ namespace Agenda {
             task_entry.name = "TaskEntry";
             task_entry.get_style_context ().add_class ("task-entry");
             task_entry.placeholder_text = HINT_STRING;
-            task_entry.max_length = 64;
+            task_entry.max_length = EDITED_TEXT_MAX_LEN;
             task_entry.hexpand = true;
             task_entry.valign = Gtk.Align.START;
             task_entry.set_icon_tooltip_text (

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -24,7 +24,7 @@ namespace Agenda {
     const int MIN_WIDTH = 500;
     const int MIN_HEIGHT = 600;
     // Limit for any edited text
-    const int EDITED_TEXT_MAX_LEN = 10;
+    const int EDITED_TEXT_MAX_LEN = 64;
 
     const string HINT_STRING = _("Add a new task…");
 


### PR DESCRIPTION
Added a value to Agenda namespace to change how many characters to accept maximum
Default value is set to 64