### PR TITLE
Add <launchable/> tag to AppStream metadata

### DIFF
--- a/data/com.github.dahenson.agenda.appdata.xml.in
+++ b/data/com.github.dahenson.agenda.appdata.xml.in
@@ -9,6 +9,7 @@
   <developer_name>Dane Henson</developer_name>
   <url type="homepage">http://brainofdane.com</url>
   <url type="bugtracker">https://github.com/dahenson/agenda/issues</url>
+  <launchable type="desktop-id">com.github.dahenson.agenda.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/dahenson/agenda/master/data/screenshot.png</image>


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-launchable-info

Omitting this tag now now triggers a hard validation error in `appstreamcli validate`:

https://github.com/ximion/appstream/commit/ad98bfd8db789c80507e82278d6d766acba4937c