### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/com.github.dahenson.agenda.appdata.xml.in
+++ b/data/com.github.dahenson.agenda.appdata.xml.in
@@ -6,7 +6,9 @@
   <project_license>GPL-3.0+</project_license>
   <name>Agenda</name>
   <summary>Get things done</summary>
-  <developer_name>Dane Henson</developer_name>
+  <developer>
+    <name>Dane Henson</name>
+  </developer>
   <url type="homepage">https://brainofdane.com</url>
   <url type="bugtracker">https://github.com/dahenson/agenda/issues</url>
   <screenshots>

--- a/data/com.github.dahenson.agenda.appdata.xml.in
+++ b/data/com.github.dahenson.agenda.appdata.xml.in
@@ -6,7 +6,7 @@
   <project_license>GPL-3.0+</project_license>
   <name>Agenda</name>
   <summary>Get things done</summary>
-  <developer>
+  <developer id="com.brainofdane">
     <name>Dane Henson</name>
   </developer>
   <url type="homepage">https://brainofdane.com</url>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

Combined with https://github.com/dahenson/agenda/pull/148, this fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: com.github.dahenson.agenda:15: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

I: com.github.dahenson.agenda:21: url-not-secure http://brainofdane.com
   Consider using a secure (HTTPS) URL for this web link.

I: com.github.dahenson.agenda:33: description-first-para-too-short
     A task manager to help you keep track of the tasks that matter most.
   The first `description/p` paragraph of this component might be too short (< 80 characters).
   Please consider starting with a longer paragraph to improve how the description looks like in
   software centers and to provide more detailed information on this component immediately in the
   first paragraph.

✔ Validation was successful: infos: 3, pedantic: 2
```

For `url-not-secure`, I plan to open a separate PR.