### PR TITLE
Implement basic printing operation support.

### DIFF
--- a/src/Models/TaskList.vala
+++ b/src/Models/TaskList.vala
@@ -276,44 +276,44 @@ namespace Agenda {
             list_changed ();
         }
 
-	public void begin_print (Gtk.PrintOperation print, Gtk.PrintContext context) {
-		print.set_n_pages(1);
-	}
+        public void begin_print (Gtk.PrintOperation print, Gtk.PrintContext context) {
+            print.set_n_pages(1);
+        }
 
-	public void draw_page (Gtk.PrintOperation print, Gtk.PrintContext context, int page_nr) {
-		var cairo = context.get_cairo_context ();
-		cairo.set_source_rgb (0, 0, 0);
-		cairo.set_line_width (1);
+        public void draw_page (Gtk.PrintOperation print, Gtk.PrintContext context, int page_nr) {
+            var cairo = context.get_cairo_context ();
+            cairo.set_source_rgb (0, 0, 0);
+            cairo.set_line_width (1);
 
-		var layout = context.create_pango_layout ();
-		var desc = new Pango.FontDescription ();
-		desc.set_family ("sans");
-		desc.set_size (14 * Pango.SCALE);
-		layout.set_font_description (desc);
+            var layout = context.create_pango_layout ();
+            var desc = new Pango.FontDescription ();
+            desc.set_family ("sans");
+            desc.set_size (14 * Pango.SCALE);
+            layout.set_font_description (desc);
 
-		layout.set_width ((int) (context.get_width () * Pango.SCALE));
-		layout.set_height ((int) (context.get_height () * Pango.SCALE));
-		layout.set_alignment (Pango.Alignment.LEFT);
-		layout.set_ellipsize (Pango.EllipsizeMode.END);
+            layout.set_width ((int) (context.get_width () * Pango.SCALE));
+            layout.set_height ((int) (context.get_height () * Pango.SCALE));
+            layout.set_alignment (Pango.Alignment.LEFT);
+            layout.set_ellipsize (Pango.EllipsizeMode.END);
 
-		string text = "";
+            string text = "";
 
-		Task[] tasks = get_all_tasks ();
-		foreach (Task t in tasks) {
-			string item = "";
+            Task[] tasks = get_all_tasks ();
+            foreach (Task t in tasks) {
+                string item = "";
 
-			if (t.complete) {
-				item = "☑\t" + t.text;
-			} else {
-				item = "☐\t" + t.text;
-			}
+                if (t.complete) {
+                    item = "☑\t" + t.text;
+                } else {
+                    item = "☐\t" + t.text;
+                }
 
-			text += item + "\n";
-		}
+                text += item + "\n";
+            }
 
-		layout.set_text (text, text.length);
-		Pango.cairo_show_layout (cairo, layout);
-	}
+            layout.set_text (text, text.length);
+            Pango.cairo_show_layout (cairo, layout);
+        }
 
         public void redo () {
             var state = undo_list.get_next_state ();

--- a/src/Models/TaskList.vala
+++ b/src/Models/TaskList.vala
@@ -276,11 +276,11 @@ namespace Agenda {
             list_changed ();
         }
 
-	private void begin_print (Gtk.PrintOperation print, Gtk.PrintContext context) {
+	public void begin_print (Gtk.PrintOperation print, Gtk.PrintContext context) {
 		print.set_n_pages(1);
 	}
 
-	private void draw_page (Gtk.PrintOperation print, Gtk.PrintContext context, int page_nr) {
+	public void draw_page (Gtk.PrintOperation print, Gtk.PrintContext context, int page_nr) {
 		var cairo = context.get_cairo_context ();
 		cairo.set_source_rgb (0, 0, 0);
 		cairo.set_line_width (1);
@@ -313,18 +313,6 @@ namespace Agenda {
 
 		layout.set_text (text, text.length);
 		Pango.cairo_show_layout (cairo, layout);
-	}
-
-        public void print () {
-		Gtk.PrintOperation print = new Gtk.PrintOperation ();
-		print.begin_print.connect (this.begin_print);
-		print.draw_page.connect (this.draw_page);
-		try {
-			var res = print.run (Gtk.PrintOperationAction.PRINT_DIALOG, null);
-			debug ("print res: %d\n", res);
-		} catch (Error e) {
-			error (e.message);
-		}
 	}
 
         public void redo () {

--- a/src/Models/TaskList.vala
+++ b/src/Models/TaskList.vala
@@ -277,7 +277,7 @@ namespace Agenda {
         }
 
         public void begin_print (Gtk.PrintOperation print, Gtk.PrintContext context) {
-            print.set_n_pages(1);
+            print.set_n_pages (1);
         }
 
         public void draw_page (Gtk.PrintOperation print, Gtk.PrintContext context, int page_nr) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -49,16 +49,19 @@ namespace Agenda {
             var app_quit_action = new SimpleAction ("quit", null);
             var undo_action = new SimpleAction ("undo", null);
             var redo_action = new SimpleAction ("redo", null);
+            var print_action = new SimpleAction ("print", null);
 
             add_action (window_close_action);
             add_action (app_quit_action);
             add_action (undo_action);
             add_action (redo_action);
+            add_action (print_action);
 
             app.set_accels_for_action ("win.close", {"<Ctrl>W"});
             app.set_accels_for_action ("win.quit", {"<Ctrl>Q"});
             app.set_accels_for_action ("win.undo", {"<Ctrl>Z"});
             app.set_accels_for_action ("win.redo", {"<Ctrl>Y"});
+            app.set_accels_for_action ("win.print", {"<Ctrl>P"});
 
             this.get_style_context ().add_class ("rounded");
             this.set_size_request (MIN_WIDTH, MIN_HEIGHT);
@@ -107,6 +110,7 @@ namespace Agenda {
             app_quit_action.activate.connect (this.close);
             undo_action.activate.connect (task_list.undo);
             redo_action.activate.connect (task_list.redo);
+            print_action.activate.connect (task_list.print);
         }
 
         private void load_list () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -110,7 +110,7 @@ namespace Agenda {
             app_quit_action.activate.connect (this.close);
             undo_action.activate.connect (task_list.undo);
             redo_action.activate.connect (task_list.redo);
-            print_action.activate.connect (task_list.print);
+            print_action.activate.connect (this.print);
         }
 
         private void load_list () {
@@ -341,6 +341,18 @@ namespace Agenda {
             });
 
             return base.configure_event (event);
+        }
+
+        public void print () {
+                Gtk.PrintOperation print = new Gtk.PrintOperation ();
+                print.begin_print.connect (task_list.begin_print);
+                print.draw_page.connect (task_list.draw_page);
+                try {
+                        var res = print.run (Gtk.PrintOperationAction.PRINT_DIALOG, this);
+                        debug ("print res: %d\n", res);
+                } catch (Error e) {
+                        error (e.message);
+                }
         }
     }
 }


### PR DESCRIPTION
This patch adds printing support with `Gtk.PrintOperation` and `Pango/Cairo`. **Useful for fridge and magnets! :-)**.
Simply pressing `<Ctrl>P` triggers the printer dialog, then printing of the whole task list is done on the selected printer.