### PR TITLE
meson: Replace deprecated source_root with project_source_root

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,7 @@ install_data(
 i18n.merge_file(
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.project_source_root(), 'po', 'extra'),
     type: 'desktop',
     install: true,
     install_dir: join_paths(get_option('datadir'), 'applications')
@@ -28,7 +28,7 @@ i18n.merge_file(
 i18n.merge_file(
     input: meson.project_name() + '.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.project_source_root(), 'po', 'extra'),
     install: true,
     install_dir: join_paths(get_option('datadir'), 'metainfo')
 )

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,4 +1,4 @@
 i18n.gettext('extra',
-    args: ['--directory='+meson.source_root(), '--from-code=UTF-8'],
+    args: ['--directory='+meson.project_source_root(), '--from-code=UTF-8'],
     install: false
 )

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(meson.project_name(),
-    args: ['--directory='+meson.source_root(), '--from-code=UTF-8']
+    args: ['--directory='+meson.project_source_root(), '--from-code=UTF-8']
 )
 
 subdir('extra')


### PR DESCRIPTION
[meson.source_root](https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonsource_root) was deprecated in 0.56.0.